### PR TITLE
Add missing command to home message

### DIFF
--- a/internal/client/router.go
+++ b/internal/client/router.go
@@ -102,7 +102,7 @@ func (c *Client) FreeTextRouter(b *gotgbot.Bot, ctx *ext.Context) error {
 	}
 
 	err = c.CleanupKeyboard(b, ctx)
-	err = errors.Join(err, c.SendHomeKeyboard(b, ctx, "Sorry I don't understand, what can I do for you?\n\n/edit - Edit a transaction\n/delete - Delete a transaction\n/search - Search transactions\n/list - List your transactions\n/week Week Recap\n/month Month Recap\n/year Year Recap\n/export - Export all transactions to CSV"))
+	err = errors.Join(err, c.SendHomeKeyboard(b, ctx, "Sorry I don't understand, what can I do for you?\n\n/list - List your transactions\n/edit - Edit a transaction\n/delete - Delete a transaction\n/search - Search transactions\n/week - Week Recap\n/month - Month Recap\n/year - Year Recap\n/export - Export all transactions to CSV\n/cancel - Cancel current operation\n/start - Show this menu again\n/new - Show this menu again"))
 	if err != nil {
 		return err
 	}

--- a/internal/client/start.go
+++ b/internal/client/start.go
@@ -17,7 +17,7 @@ func (c *Client) Start(b *gotgbot.Bot, ctx *ext.Context) error {
 		return errors.Join(err, errm)
 	}
 
-	msg := fmt.Sprintf("Welcome to Cashout, %s!\nWhat can I do for you?\n\n/edit - Edit a transaction\n/delete - Delete a transaction\n/search - Search transactions\n/list - List your transactions\n/week Week Recap\n/month Month Recap\n/year Year Recap\n/export - Export all transactions to CSV", user.Name)
+	msg := fmt.Sprintf("Welcome to Cashout, %s!\nWhat can I do for you?\n\n/list - List your transactions\n/edit - Edit a transaction\n/delete - Delete a transaction\n/search - Search transactions\n/week - Week Recap\n/month - Month Recap\n/year - Year Recap\n/export - Export all transactions to CSV\n/cancel - Cancel current operation\n/start - Show this menu again\n/new - Show this menu again", user.Name)
 
 	err = c.SendHomeKeyboard(b, ctx, msg)
 

--- a/internal/client/transactions.go
+++ b/internal/client/transactions.go
@@ -662,7 +662,7 @@ func (c *Client) Cancel(b *gotgbot.Bot, ctx *ext.Context) error {
 	}
 
 	err = c.CleanupKeyboard(b, ctx)
-	err = errors.Join(err, c.SendHomeKeyboard(b, ctx, "Your operation has been canceled!\nWhat else can I do for you?\n\n/edit - Edit a transaction\n/delete - Delete a transaction\n/search - Search transactions\n/list - List your transactions\n/week Week Recap\n/month Month Recap\n/year Year Recap\n/export - Export all transactions to CSV"))
+	err = errors.Join(err, c.SendHomeKeyboard(b, ctx, "Your operation has been canceled!\nWhat else can I do for you?\n\n/list - List your transactions\n/edit - Edit a transaction\n/delete - Delete a transaction\n/search - Search transactions\n/week - Week Recap\n/month - Month Recap\n/year - Year Recap\n/export - Export all transactions to CSV\n/cancel - Cancel current operation\n/start - Show this menu again\n/new - Show this menu again"))
 
 	return err
 }


### PR DESCRIPTION
Added /cancel, /start, and /new commands to the home message that appears at bot start and when operations complete. These commands were already functional but not documented in the user-facing menu.

Updated in three locations:
- internal/client/start.go: Welcome message
- internal/client/router.go: Error fallback message
- internal/client/transactions.go: Cancellation message